### PR TITLE
Prospectus links

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -19,6 +19,7 @@ hero-image-alt: "Library of Congress Interior"
 
 
 toggles:
+  call-for-sponsors: true
   livestream: false
   prop-shirt: false
   prop-shop: false

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,7 +10,11 @@
             <li class="list-item tci"><a href="/speakers/past-keynotes.html">Speakers</a></li>
             <!-- <li class="list-item tci"><a href="/speakers/index.html">Speakers</a></li> -->
             <!-- <li class="list-item tci"><a href="/venue">Venues</a></li> -->
-            <li class="list-item tci"><a href="/sponsors">Sponsors</a></li>
+            {% if site.data.conf.toggles.call-for-sponsors %}
+                <li><a href="/prospectus">Sponsors</a></li>
+            {% else %}
+                <li><a href="/sponsors">Sponsors</a></li>
+            {% endif %}
             <li class="list-item tci"><a href="/conduct">Conduct</a></li>
             <li class="list-item tci"><a href="/about">About</a></li>
         </ul>

--- a/_includes/jumbotron.html
+++ b/_includes/jumbotron.html
@@ -30,6 +30,10 @@
 
                     <!-- Preconference events -->
                     <a class="btn btn-lg jumbotron-btn" href="/schedule/timeline.html">What's Going On?</a>
+
+                    {% if site.data.conf.toggles.call-for-sponsors %}
+                        <a class="btn btn-lg jumbotron-btn" href="/prospectus">Sponsor Code4Lib!</a>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -72,8 +72,15 @@
                 </li>
                 -->
 
-                <!-- sponsors is always active -->
-                <li><a href="/sponsors">Sponsors</a></li>
+                {% comment %}
+                when looking for sponsors before conf, send users to prospectus
+                close to / during conf, send to the list of sponsors page
+                {% endcomment %}
+                {% if site.data.conf.toggles.call-for-sponsors %}
+                    <li><a href="/prospectus">Sponsors</a></li>
+                {% else %}
+                    <li><a href="/sponsors">Sponsors</a></li>
+                {% endif %}
 
                 <!-- turn on scholarships once applications are being accepted
                 <li><a href="/diversity-scholarships/recipients.html">Scholarships</a></li>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -107,7 +107,7 @@ p {
     border: 2px solid $jumbotron-btn-color;
     color: $jumbotron-btn-color;
     border-radius: 0;
-    margin-top: .5em;
+    margin: .5em .5em 0 0;
   }
 
   .btn:hover {
@@ -168,7 +168,7 @@ p {
     max-width: 1050px;
     margin: 0 auto;
     .btn {
-      margin-bottom: 0;
+      margin-right: 1em;
       float: left;
     }
   }


### PR DESCRIPTION
adds a button to the `#conferenceActions` on home page, changes header & footer "sponsors" links to go straight to prospectus if `call-for-sponsors: true` in _data/conf.yml.