### PR TITLE
add ongoing LPC vote to timeline

### DIFF
--- a/schedule/timeline.html
+++ b/schedule/timeline.html
@@ -117,6 +117,18 @@ categories: Schedule
                 <h2 style="border-bottom:1px solid; padding-bottom:5px;">Proposals</h2>
             </div>
 
+            {% comment %}
+                one-time vote on a few conference structure questions
+            {% endcomment %}
+            <div class="col-xs-12 col-sm-7">
+                <h3>Program Committee Vote</h3>
+                <p>A community vote on a few matters concerning the 2018 conference.</p>
+            </div>
+            <div class="col-xs-12 col-sm-5 text-right">
+                <h3><small class="light" style="color: inherit">Now until August 25<sup>th</sup></small></h3>
+                <a class="btn btn-primary" href="http://vote.code4lib.org/election/46">Vote!</a>
+            </div>
+
             <!-- T-shirts -->
             {% if site.data.conf.shirt-proposals.show %}
                 <div class="col-xs-12 col-sm-7">


### PR DESCRIPTION
The `<small>` font color was way too light against the background so I added an inline style for now. I want to revisit that because I'm not sure how it affects other places, the source of the style is line 933 of assets/_scss/_variables:

```scss
$headings-small-color:        $gray-light !default;
```