### PR TITLE
adding basic venue info to the welcome to washington section

### DIFF
--- a/_includes/homepage/going_on_block.html
+++ b/_includes/homepage/going_on_block.html
@@ -1,9 +1,9 @@
-<div class="row">
+<div class="row" style="margin-top: 1em;">
     <div class="col-xs-12 col-sm-6 col-md-5">
         {% if include.primary %}
-        <h4>{{ include.title }}</h4>
+        <h4 style="margin-top:0;">{{ include.title }}</h4>
         {% else %}
-        <h5>{{ include.title }}</h5>
+        <h5 style="margin-top:0;">{{ include.title }}</h5>
         {% endif %}
         {% if include.more-info-link.size %}
             <a href="{{ include.more-info-link }}">

--- a/index.html
+++ b/index.html
@@ -52,9 +52,11 @@ title: code4lib 2018 - Washington, D.C.
             </div>
             <div class="col-sm-10">
                 <h2>Welcome to Washington, D.C.</h2>
-                <!--
-                TODO: DC blurb here
-                -->
+                <p>
+                    The conference will take place in Washington's historic <a href="https://www.omnihotels.com/hotels/washington-dc-shoreham">
+                    Omni Shoreham Hotel</a>, just a couple blocks from the Woodley Park metro station, walking distance
+                    to the National Zoo and bustling Adams Morgan neighborhood.
+                </p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
per #60, I've temporarily added this information to the last section "Welcome to Washington", since we didn't have anything in there anyway.

If that's too low on the page, we could swap the tweets section with welcome to washington.