### PR TITLE
Open keynote voting, issue #79

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -59,9 +59,9 @@ shirt-proposals:
 # Voting
 ###########
 keynote-voting:
-  show: false
-  url: ""
-  end-date:
+  show: true
+  url: "https://www.surveymonkey.com/r/c4l2018-keynote"
+  end-date: "2017-11-13"
 
 workshop-voting:
   show: false

--- a/_data/keynote-nominees.yml
+++ b/_data/keynote-nominees.yml
@@ -1,0 +1,95 @@
+- name: "Rosalyn Metz"
+  slug: 64212795
+  bio: |
+    Rosalyn is the Director of Library Technology and Digital Strategies at Emory University. In this role, she sets the strategic agenda for technology across the Emory Libraries and serves as a leader in the greater Atlanta (Georgia) area on regional technology collaborations. She’s had a wide range of experience both in libraries and out, with a career ranging from being a systems administrator to being a project manager to serving as a library administrator. She has been active in the Code4Lib community, serves on Fedora Steering, is active in the Samvera community, serves on the DPN program directions committee, and has been heavily involved in the Women in Library Technology community. Rosalyn is passionate about process development, community development, and human development. She believes strongly that by focusing on these three areas the profession can be moved forward in a thoughtful and innovative way. Outside of work, Rosalyn is a yogi, breadwinning mom, animal whisperer, and a flying trapeze artist.
+
+- name: "Jeffrey Spies, Ph.D."
+  slug: 32688289
+  bio: |
+    Dr. Spies is the CTO and co-founder of the Center for Open Science, a non-profit technology company missioned to increase the openness, integrity, and transparency of research. His research and interests are motivated by increasing research efficiency. As CTO at COS he is responsible for technical strategy, product vision, software architecture, external partner/funder development, and management of COS Labs-COS's research and development team. He also co-lead's SHARE - an initiative by the Association of Research Libraries and COS to create a free, open dataset of research activity across the research life-cycle.
+
+- name: "Terry Brady"
+  slug: 45449375
+  bio: |
+    Terry Brady is a software developer in Seattle working for the Georgetown University Library. Terry is the lead developer for DigitalGeorgetown. Terry is a committer for the DSpace repository platform. Terry has built applications for higher education, government, non-profit, and corporate institutions including LexisNexis and the National Archives and Records Administration--including the amazingly handy File-Analyzer. Strengthening communities is a passion of Terry's: he regularly participates in the DSpace Community Advisory Team meetings, and initiated the recent DSpace Users Group meeting hosted by Georgetown University in August of 2017. Terry does what all developers do, he writes code enthusiastically, and many times for no personal advantage, merely because it's work that needs doing, or is an interesting challenge. His work inspires that same approach in others; his observations on the work we all do will be equally inspiring.
+
+- name: "Jessica Marie Johnson"
+  slug: 35964668
+  bio: |
+    Jessica Marie Johnson is an assistant professor of history at Johns Hopkins University in Baltimore. Her work is focused around radical black feminist praxis in the digital humanities. One of her more recent projects is titled "The Codex" a triptych that also functions as an exploration of the Atlantic slave trade by using code and software applications.
+
+- name: "Mega Subramaniam"
+  slug: 91941154
+  bio: |
+    Mega Subramaniam is an Associate Professor at the College of Information Studies at the University of Maryland. Dr. Subramaniam is the fellow for the Libraries Ready to Code (RtC) project led by the Office for Information Technology Policy at the American Library Association (ALA OITP), which is funded by Google, Inc. Dr. Subramaniam has been instrumental in assisting ALA OITP in planning and implementing the activities for all the three RtC phases, hence has great insights on how librarians can be Ready to Code. The RtC project ultimate goals are to develop a mindset for library services for and with youth that puts youth interests at the center of the learning, to provide opportunities for youth to engage in planning & implementation of computational and coding programs in libraries, to focus on facilitation, and to provide opportunities for community members to coach and mentor youth in computational thinking. Dr. Subramaniam’s work focuses on enhancing the role of libraries in fostering the mastery of new media literacies that are essential for STEM learning among underserved young people. She is the lead PI for the IMLS-funded Graduate Certificate of Professional Studies in Youth Experience (YX) and developed a new YX specialization within MLIS, that allows in-service and pre-service librarians to develop skills to facilitate programs and services that foster computational thinking and other emerging literacies in youth from birth to 18. Dr. Subramaniam holds a bachelor’s degree in Education (Mathematics and Computers in Education) from the Universiti Teknologi Malaysia, received her master’s degree in Instructional Systems Technology from Indiana University, Bloomington, and her Ph.D. in Information Studies from Florida State University.
+
+- name: "Elrick Ryan"
+  slug: 43873435
+  bio: |
+    Elrick is a mashup of developer and designer he has coined Devsigner X. He holds bachelors degrees in both Web Development and Multimedia Design. Capable of taking ideas all the way from a dot grid notebook, through the design phase, and into production, he loves the challenge of bringing amazing design to life with code. Creativity is in his blood. Problem solving is at his core. Collaboration is in his heart. He fell in love with code because of design and because of Flash fell in love with JavaScript and has never looked back. He has designed for many different mediums and has written code across the full breadth of the stack which makes him truly The B.O.A.T. -- The Builder Of All Things.
+
+- name: "Kate Deibel"
+  slug: 72230790
+  bio: |
+    Kate Deibel is the Inclusion & Accessibility Librarian at Syracuse University. An ardent advocate for usable and accessible technologies, her work focuses on disciplinarity, technology adoption, comics, and disability. Kate earned her PhD in computer science and engineering at the University of Washington in 2011 with a multidisciplinary study of the social and technological factors that hinder adoption of reading technologies among adults with dyslexia, and while working as a web applications specialist at the University of Washington Libraries she focused on ensuring that technologies are effective tools for both library patrons and staff. By challenging the assumptions that we make about accessibility and our patrons' experiences with library technology, Kate's work pushes us to be more empathetic, realistic, and creative when we design library systems.
+
+- name: "Kate Zwaard"
+  slug: 43354802
+  bio: |
+    Kate Zwaard was named the Chief of National Digital Initiatives at Library of Congress in August 2016 after 5 years work as the product manager for digital repository development in the LoC. Prior to her work at LoC, she worked at the US Government Printing Office as program development specialist and then as their lead program planner. Kate and her NDI group recently launched LoC Labs, a platform to encourage innovation with Libarry of Congress digital collections, in September 2017. Her experience as programmer and then as a leader gives her great insights from several perspectives.
+
+- name: "Pamela Wright"
+  slug: 24492787
+  bio: |
+    Pamela Wright is the U.S. National Archives' first Chief Innovation Officer. She oversees the Agency's online public access Catalog, web, social media, and authorities programs as well as the Innovation Hub. She has hosted coding communities and worked with other institutions to help the Agency become a more digital, citizen-centric institution. She has a goldmine of content and adores coders who can do interesting and enlightening things with it. She launched the Citizen Archivist Dashboard, which has been a gateway for the public to engage in new ways with our content. She is currently collaborating with staff from the Smithsonian and Library of Congress on History Hub.
+
+- name: "Carla Hayden"
+  slug: 61688373
+  bio: |
+    Carla is the US Librarian of Congress. She is the first female and first African American to hold this post. She has previously worked in public libraries, the Chicago Museum of Science and Industry, and headed the American Library Association. Her position and vast experience would make her an excellent candidate. She could potentially discuss how technology and the library intersect at the highest level of US government.
+
+- name: "David Brunton"
+  slug: 72345013
+  bio: |
+    David Brunton was hired is the Chief of Repository Development at the Library of Congress. In his time here, David has contributed to a number of important group efforts at LC, including: electronic Copyright Deposit, the Twitter archive, the National Digital Newspaper Program, digitization workflow, and more recently, crowdsourcing. David's first library job and his first coding job were both during his undergraduate years in the mid-nineties, and he has been doing one, the other, and both ever since. David is a fun and engaging speaker.
+
+- name: "Chris Bourg"
+  slug: 49954431
+  bio: |
+    Chris Bourg is the Director of Libraries at Massachusetts Institute of Technology (MIT), where she also has oversight of the MIT Press. Prior to assuming her role at MIT, Chris worked for 12 years in the Stanford University Libraries, most recently as the Associate University Librarian for Public Services. Chris is keenly interested in issues of diversity and inclusion in higher education; and in the role libraries play in advancing social justice and democracy. She is currently serving as Chair of the Committee on Diversity and Inclusion of the Association of Research Libraries and has written and spoken extensively on diversity, inclusion, and leadership. Chris has a PhD in Sociology from Stanford University, and spent 10 years as an active duty U.S. Army officer, including 3 years on the faculty at the United States Military Academy at West Point.
+
+
+- name: "Timothy C. Summers"
+  slug: 53355671
+  bio: |
+    Dr. Summers, a world leading expert on how hackers think and normal chaos [https://www.howhackersthink.org/](https://www.howhackersthink.org/), is a hacker, professor, author, frequent media commentator, TED speaker, and consulted expert. He is a trusted advisor and consultant to Fortune 500 companies, academic institutions, and governments worldwide. He specializes in the scholarship and practice of hacker cognitive psychology (the hacking mindset) and the normal chaos paradigm, enabling him to advise organizations on handling uncertainty. Timothy is the CEO of Summers & Company, a strategic management and cyber advisory firm that uses scholarship and practice techniques to evaluate management decisions to ensure that organizations can deal with a variety of uncertainty. He is the Founder of WikiBreach.org, a public database of cyber breach data which scrapes the Internet for cyber-attacks as they happen and he is Co-Founder of the Normal Chaos Group, an organizational practice and research think tank dedicated to the pragmatic approach of normal chaos as a paradigm for business, government, and non-governmental organizations for organizational advancement. Timothy is the Director of Innovation, Entrepreneurship & Engagement within the College of Information Studies (Maryland’s iSchool) at the University of Maryland, College Park. He is frequently requested to provide expert commentary by domestic and international media outlets and academic institutions on topics of risk and cyber crises. Timothy carries a Scientiae Baccalaureus in Computer Science from Elizabeth City State University, Scientiae Magister in Information Security Policy and Management from Carnegie Mellon University, and a Doctor of Philosophy in Organizational Management from Case Western Reserve University.
+
+- name: "Gene Luen Yang"
+  slug: 62890169
+  bio: |
+    Comic artist and author, Gene Yang has greatly broadened diversity representation in comics with successful titles such as American Born Chinese, Boxers and Saints, and The Shadow Hero. In 2016, the Library of Congress named him as an Ambassador for Young People’s Literature. In this capacity, Yang has pushed a mission of 'Reading Without Walls' to encourage literacies of all types. Additionally, he has recently started a graphic novel series, Secret Coders with artist Mike Holmes. This series aims to introduce kids to actual magic they can perform at home: computer programming. As several kids try to uncover the mysteries of their school, they face puzzles and challenges that teach readers about programming.
+
+- name: "Gregg Vanderheiden"
+  slug: 09086974
+  bio: |
+    Gregg Vanderheiden is a Professor in the iSchool and Director of Trace R&D Center at the University of Maryland – College Park. He directs the Rehabilitation Engineering Research Center on Universal Interface and Information Technology Access (NIDILRR/ACL) and co-directs Raising the Floor, an international consortium of companies and organizations building the Global Public Inclusive Infrastructure (GPII). Has worked in technology and disability for over 45 years; was a pioneer in Augmentative Communication (a term taken from his writings in 1979), and in cross-disability access to ICT of all types. His work is found in computers, phones, Automated Postal Stations, Amtrak ticket machines, and airport terminals. Most of the initial access features in both Microsoft Windows and Apple Mac operating systems came from his Center. He co-chaired both WCAG 1.0 and 2.0 working groups, and has worked with over 50 companies and numerous government advisory & planning committees including FCC, NSF, NIH, GSA, NCD, Access Board and White House. He has received over 30 awards for his work on technology and disability. He is a past President of RESNA and a Founding Fellow of the American Institute of Medical and Biological Engineering (AIMBE). Dr. Vanderheiden holds degrees in electrical engineering and biomedical engineering. He received his Ph.D. in Technology in Communication Rehabilitation and Child Development, an interdisciplinary degree between the departments of Electrical Engineering, Communicative Disorders, Rehabilitation Psychology & Special Education and Educational Psychology, from the University of Wisconsin - Madison.
+
+- name: "Veni Kunche"
+  slug: 34840690
+  bio: |
+    Veni Kunche is a coder, maker, and mentor who works at the U.S. Geological Survey (as a Sr. Software Engineer) and Blasterra (as CEO and Founder). At Blasterra, she focuses on developing programs for people learning to code, but also focuses on teaching women to code. She is based in D.C..
+
+- name: "Whitni Watkins"
+  slug: 94234466
+  bio: |
+    Whitni Watkins’ carefully curated set of hard skills, spanning library systems, languages, and operating systems, allows her to thrive as a web services engineer at one of the United States’ largest technology corporations, serving over 100,000 customers worldwide. But it is Ms. Watkins’ passion for creating empathetic communities at the intersection of technology, libraries, and education that set her apart as a thoughtful technologist with an uncanny ability to understand not only computer systems but also the social systems in which technologists work. This passion has led her to work with Girls Who Code, to establish Boston’s LibTechrs meetup group which is open to all with an interest in technology, to lead the Massachusetts Library Association’s technology group, and to encourage women to enter technology fields and to feel accepted and confident in those fields. A sought-after public speaker, having spoken at Electronic Resources & Libraries, Code4Lib, and ALA Annual and MidWinter, as well as many other conferences in the United States and Canada, including as Keynote at EBSCO Presents, Ms. Watkins would craft and deliver a keynote that brings us together from our diverse viewpoints and ready us for the conference for people who code for libraries.
+
+- name: "Bess Sadler"
+  slug: 53413562
+  bio: |
+    Bess Sadler is a library coding (and Code4Lib) institution. Bess has been building digital repositories for over fifteen years. She is a co-founder of both the Blacklight and Hydra Samvera software projects, and is a passionate advocate for open source software and DevOps culture. Before joining DCE, Bess was the Manager for Application Development at Stanford University Library, where she managed a portfolio that included EarthWorks, Library Systems, DevOps, linked data infrastructure development, and strategic planning for long term digital preservation and sustainable development practices. In her spare time, Bess enjoys gardening, cooking, contributing to social justice movements, and reading comic books.
+
+- name: "Shane Lin"
+  slug: 08013107
+  bio: |
+    Shane studies the history of computing and the impact of digital technology on culture and politics. His dissertation, ‘Kingdom of Code: Cryptography and the New Privacy’ tracks the development of civilian encryption technology and the emergence of cryptography as an academic field of study, the debates over crypto regulation, and the concomitant construction of a new, far more expansive notion of privacy from 1975 to 2000. His perspectives on technology, encryption, and privacy would be especially interesting to a wide audience.

--- a/_includes/homepage/pre_conference.html
+++ b/_includes/homepage/pre_conference.html
@@ -24,7 +24,7 @@
             {% if site.data.conf.keynote-voting.show %}
                 {% include homepage/going_on_block.html
                     title='Keynote Speakers'
-                    more-info-link=''
+                    more-info-link='/keynote/keynote-nominees.html'
                     more-info-text='View the nominees'
                     end-date=site.data.conf.keynote-voting.end-date
                     url=site.data.conf.keynote-voting.url

--- a/keynote/index.html
+++ b/keynote/index.html
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Keynote Speaker
+---
+
+<div class="container">
+    <div class="row">
+        <div class="col-xs-12">
+            <h1>{{ page.title }}</h1>
+            <p></p>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-xs-12 sequence">
+        </div>
+    </div>
+</div>

--- a/keynote/keynote-nominees.html
+++ b/keynote/keynote-nominees.html
@@ -1,0 +1,35 @@
+---
+layout: default
+---
+
+<div class="container">
+    <div class="row">
+
+        <div class="col-xs-12 col-sm-8">
+            <h3>Proposed Keynote Nominees</h3>
+        </div>
+        <div class="col-xs-12 col-sm-4">
+            {% if site.data.conf.keynote-voting.show %}
+                <a class="btn btn-primary pull-right" href="{{ site.data.conf.keynote-voting.url }}">Vote!</a>
+            {% endif %}
+        </div>
+        <div class="col-xs-12 col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2">
+            {% for keynote in site.data.keynote-nominees %}
+            <div class="panel panel-default">
+                <div class="panel-heading" role="tab" id="{{ keynote.slug }}Header">
+                    <h4 class="panel-title">
+                        <a role="button" data-toggle="collapse" data-parent="#list-of-keynotes" href="#{{ keynote.slug }}" aria-expanded="true" aria-controls="{{ keynote.slug }}">
+                            {{ keynote.name }}
+                        </a>
+                    </h4>
+                </div>
+                <div id="{{ keynote.slug }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="{{ keynote.slug }}Header">
+                    <div class="panel-body">
+                        <p>{{ keynote.bio | markdownify }}<p>
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Open keynote voting, and add a placeholder page for /keynote. Resolves #79.