### PR TITLE
Removes copy from 2017 conference from the workshop page

### DIFF
--- a/workshops/index.html
+++ b/workshops/index.html
@@ -6,12 +6,12 @@ title: Preconference Workshops
 <div class="container">
     <div class="row">
         <div class="col-xs-12">
-            <h1>{{ page.title }}<!-- : March 6th, 2017 --></h1>
+            <h1>{{ page.title }}</h1>
         </div>
     </div>
     <div class="row">
         <div class="col-xs-12 col-sm-12">
-            <p>Registration will open at <strong>8 a.m.</strong> in the Luskin Center &mdash; Centennial Ballroom Foyer.  UCLA volunteers will be available at Luskin and guiding groups to the different Preconference Workshops at 8:30 a.m., 8:45 a.m., and 1:00 p.m.</p>
+            <p>Preconference Workshops will start at 9:00 a.m. and 2:00 p.m.</p>
         </div>
     </div>
     <div class="row" id="workshop-sorting-div">


### PR DESCRIPTION
I forgot to clean the workshop layout of UCLA/2017 references.