### PR TITLE
make schedule & speaker list live

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -102,10 +102,10 @@ workshop-registration:
 # "show" just means display on home page, "open" means people can register
 conference-registration:
   show: true
-  url:
+  url: http://www.cvent.com/d/3tqn5s/4W
   start-date: "2017-12-06"
   end-date:
-  open: false
+  open: true
 
 ###################
 # Misc

--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -13,7 +13,7 @@ call-for-sponsors: false
 search: false
 # If false (we don't have program info yet), the main nav links go:
 # schedule -> preparation timeline, speakers -> past keynotes
-program-nav-links: false
+program-nav-links: true
 
 ###################
 # Homepage section

--- a/_includes/homepage/pre_conference.html
+++ b/_includes/homepage/pre_conference.html
@@ -5,7 +5,7 @@
     {% if site.data.conf.conference-registration.show %}
         {% include homepage/going_on_block.html
             primary=true
-            title='Registration fee announced!'
+            title='Conference Registration'
             more-info-link='/general-info/attend'
             more-info-text='Fees & additional information'
             end-date=site.data.conf.conference-registration.end-date

--- a/general-info/venues/dinner.html
+++ b/general-info/venues/dinner.html
@@ -8,7 +8,7 @@
       <div class="container">
           <div class="row">
               <div class="col-md-12">
-                  <p><strong>When: </strong>Monday, March 6th</p>
+                  <p><strong>When: </strong>Tuesday, February 13th</p>
                   <p>The Newcomer Dinner is an opportunity for veterans of the
                   code4lib conference to meet and welcome first-timers. Attendees
                   sign up to join others for dinner the night before the main

--- a/schedule/index.html
+++ b/schedule/index.html
@@ -12,7 +12,7 @@ title: Schedule
 
     <div class="row">
         <div class="col-xs-12 col-md-3 text-right">
-            <h4>9AM - 4:30PM</h4>
+            <h4>9AM - 5PM</h4>
         </div>
         <div class="col-xs-12 col-md-9 sched-well">
             <h3><a href="/workshops">Preconference Workshops</a></h3>
@@ -73,40 +73,6 @@ title: Schedule
         </div>
     </div>
 
-    {% comment %}
-    <!-- reception details, uncomment when we can announce on dec. 6th -->
-    <div class="row">
-        <div class="col-xs-12 col-md-3 text-right">
-            <h4>6PM - 8PM</h4>
-        </div>
-        <div class="col-xs-12 col-md-9 sched-well">
-            <a href="/venue/reception.html">
-                <h3>Opening Reception</h3>
-            </a>
-            <img class="thumbnail" width="500px" src="http://www.fowler.ucla.edu/wp-content/uploads/2015/12/Courtyard.jpg" alt="The Fowler Museum">
-            <p>
-                All attendees are invited to join us for an opening reception at UCLA's own <a href="http://www.fowler.ucla.edu/">Fowler Museum</a> which "explores global arts and cultures with an emphasis on works from Africa, Asia, the Pacific, and the Americas—past and present."
-            </p>
-            <!-- menu and drinks still TBD
-            <p>
-                The reception includes an open bar and free access to the museum exhibits from 5:45PM through
-                7:45PM.  We will also provide a selection of vegan, vegetarian, and omnivore friendly appetizers
-                featuring: Pennsylvania flatbreads, a locally-sourced variety of sausages, and a Mediterranean
-                spread that includes three different varieties of hummus and other plates.
-            </p>
-            -->
-            <!-- No reception sponsor this year
-
-            <p>
-                Special thanks to the Knight Foundation for sponsoring the reception.
-                <img width="200px" src="/assets/img/logos/knight-logo.svg" alt="The John S. and James L. Knight Foundation">
-            </p>
-            -->
-
-        </div>
-    </div>
-    {% endcomment %}
-
     <div class="row">
         <div class="col-xs-12 sched-date">
             <h2>Thursday, February 15th</h2>
@@ -130,6 +96,24 @@ title: Schedule
             {% endcomment %}
         </div>
     </div>
+
+    {% comment %}
+    add reception details when we can announce on dec. 6th
+    {% endcomment %}
+    <div class="row">
+        <div class="col-xs-12 col-md-3 text-right">
+            <h4>Evening</h4> {% comment %} replace with actual hours {% endcomment %}
+        </div>
+        <div class="col-xs-12 col-md-9 sched-well">
+            <a href="/general-info/venues/#reception">
+                <h3>Opening Reception</h3>
+            </a>
+            <p>
+                All attendees are invited to join us for the opening reception at the Great Hall at the Library of Congress. More details will be announced on this site shortly.
+            </p>
+        </div>
+    </div>
+
 
     {% comment %}
         <!-- play-n-share, move this section to the right date/time -->

--- a/schedule/index.html
+++ b/schedule/index.html
@@ -17,11 +17,11 @@ title: Schedule
         <div class="col-xs-12 col-md-9 sched-well">
             <h3><a href="/workshops">Preconference Workshops</a></h3>
             <p>
-                Preconference details are available on the <a href="/workshops">Preconference Workshops</a> page
-                {% comment %}
-                    and at the <a href="https://www.eventsforce.net/concentra/frontend/reg/tDailyAgenda.csp?pageID=7678&eventID=14&popup=1&eventID=14">registration site</a>
-                {% endcomment %}
-                .
+                Preconference details are available
+                {% if site.data.conf.workshop-registration.url.size > 0 %}
+                    on the <a href="{{site.data.conf.workshop-registration.url}}">registration site</a> and
+                {% endif %}
+                on the <a href="/workshops">Preconference Workshops</a> page.
             </p>
         </div>
     </div>

--- a/schedule/index.html
+++ b/schedule/index.html
@@ -26,12 +26,14 @@ title: Schedule
         </div>
     </div>
 
+    {% comment %}
+    <!-- newcomer dinner, turn on when details/links are known -->
     <div class="row">
         <div class="col-xs-12 col-md-3 text-right">
             <h4>Evening</h4>
         </div>
         <div class="col-xs-12 col-md-9 sched-well">
-            <h3><a href="/venue/dinner.html">Newcomer Dinner</a></h3>
+            <h3><a href="/general-info/venues/#dinner">Newcomer Dinner</a></h3>
             <p>
                 It is a Code4Lib tradition to welcome those who are new to the conference
                 by organizing dinner groups on the night before the general conference begins.
@@ -39,13 +41,12 @@ title: Schedule
                 on the wiki, and we try to mix a few newcomers with a few veterans
                 who can offer an informal introduction to the conference.  Great for making new friends!
             </p>
-            {% comment %}
-                <p>
-                    <a class="btn btn-default" href="https://docs.google.com/document/d/1UCLr7wdwDyJaJ77naTUwYmqGzngYiZprgK7T4w8to4c/edit?usp=sharing">Sign-up for the Newcomer Dinner</a>
-                </p>
-            {% endcomment %}
+            <p>
+                <a class="btn btn-default" href="https://docs.google.com/document/d/1UCLr7wdwDyJaJ77naTUwYmqGzngYiZprgK7T4w8to4c/edit?usp=sharing">Sign-up for the Newcomer Dinner</a>
+            </p>
         </div>
     </div>
+    {% endcomment %}
 
     <div class="row">
         <div class="col-xs-12 sched-date">
@@ -153,9 +154,9 @@ title: Schedule
                 <a href="childcare.html">Childcare offered</a>, thanks to Equinox and CurateCamp.
                 -->
             </p>
-            <!--
+            {% comment %}
             <p><a href="/schedule/day-3">See the full schedule</a>.</p>
-            -->
+            {% endcomment %}
         </div>
     </div>
 


### PR DESCRIPTION
ref #147 

- swap schedule & speaker menu links to point at schedule/index & speakers/index (instead of schedule/timeline & speakers/past-keynotes)
- edits to schedule index

this doesn't close 147, we're still waiting on the full program details