### PR TITLE
preconference.html - better distinction between registration shown vs open

### DIFF
--- a/_includes/homepage/pre_conference.html
+++ b/_includes/homepage/pre_conference.html
@@ -1,11 +1,24 @@
 <div class="col-xs-12">
     <h3>What's going on?</h3>
 
-    <!-- register/attend -->
-    {% if site.data.conf.conference-registration.show %}
+    {% comment %} details known/announced but can't register yet {% endcomment %}
+    {% if site.data.conf.conference-registration.show
+    and site.data.conf.conference-registration.open == false %}
         {% include homepage/going_on_block.html
             primary=true
             title='Registration fee announced!'
+            more-info-link='/general-info/attend'
+            more-info-text='Fees & additional information'
+            end-date=site.data.conf.conference-registration.end-date
+            start-date=site.data.conf.conference-registration.start-date
+        %}
+    {% endif %}
+
+    {% comment %} registration is open! {% endcomment %}
+    {% if site.data.conf.conference-registration.open %}
+        {% include homepage/going_on_block.html
+            primary=true
+            title='Registration is open!'
             more-info-link='/general-info/attend'
             more-info-text='Fees & additional information'
             end-date=site.data.conf.conference-registration.end-date


### PR DESCRIPTION
This will just simplify opening registration; no need to mess about with these conference includes, the `conference-registration.open` switch will change the "going_on_block.html" on the home page.