### PR TITLE
Updated list with giveaway sponsors

### DIFF
--- a/_data/sponsors.yml
+++ b/_data/sponsors.yml
@@ -184,3 +184,15 @@
 - name: Washington Research Library Consortium
   link: https://www.wrlc.org/
   level: supporter
+  
+- name: Oxygen XML Editor
+  link: https://www.oxygenxml.com/
+  level: giveaway
+  
+- name: Rosenfeld Media
+  link: http://rosenfeldmedia.com/
+  level: giveaway
+  
+- name: JetBrains
+  link: https://www.jetbrains.com/
+  level: giveaway


### PR DESCRIPTION
List now have giveaway sponsors (new category). Their associated logos (in giveaway logos folder) have yet to be uploaded.