### PR TITLE
add bios for several scholarship recipients

### DIFF
--- a/_data/scholarship-recipients.yml
+++ b/_data/scholarship-recipients.yml
@@ -1,8 +1,8 @@
 - name: Nicola Andrews
-  bio: ""
-  twitter-handle: ""
+  bio: "Nicky Andrews is an NCSU Libraries Fellow at North Carolina State University; cross-appointed within the Learning Spaces & Services and Libraries Human Resources departments.  Through her work, she hopes to help ensure that digital spaces and learning technologies uphold equity and accessibility, and is excited to learn alongside her Code4Lib colleagues."
+  twitter-handle: "maraebrarian"
 - name: Carly Bogen
-  bio: ""
+  bio: "Carly is the Manager of Digital Programs at the NYC Department of Records & Information Services. She is thrilled to collaborate with the Code4Lib community in order to advance the city's ability to use technology to preserve and provide access to the historical and contemporary records of New York City government."
   twitter-handle: ""
 - name: Laura Chuang
   bio: ""
@@ -14,8 +14,8 @@
   bio: ""
   twitter-handle: ""
 - name: Crystal Felima
-  bio: ""
-  twitter-handle: ""
+  bio: "Crystal Felima is a CLIR Postdoctoral Fellow in Caribbean Studies Data Curation at the University of Florida. By connecting with the Code4Lib community, Felima is excited to learn more from a range of individuals including librarians, curators, and programmers to enhance my skills in technology and to further my emerging interests in digital scholarship."
+  twitter-handle: "phelima"
 - name: Tiffany Henry
   bio: ""
   twitter-handle: ""
@@ -23,17 +23,17 @@
   bio: ""
   twitter-handle: ""
 - name: Dominique Luster
-  bio: ""
+  bio: "Dominique Luster is a proud Kentuckian, transplanted to Pittsburgh for school and work; and currently serve as the Teenie Harris Archivist at the Carnegie Museum of Art. The Teenie Harris Archive consists of almost 80,000 black and white images dating from the 1930s to the 1970s; documenting what might be one of the most complete insights into African American urban life at that time."
   twitter-handle: ""
 - name: Sonoe Nakasone
-  bio: ""
-  twitter-handle: ""
+  bio: "Sonoe Nakasone is Lead Librarian for Metadata Technologies at NCSU Libraries.  She's excited to make it to Code4Lib this year, learn a lot in the process, and finally go to the Smithsonian's National Museum of African American History and Culture."
+  twitter-handle: "sonoenakasone"
 - name: Gina Nortonsmith
-  bio: ""
-  twitter-handle: ""
+  bio: "Gina Nortonsmith is a first year MLIS student at University at Buffalo, concentrating in archives and special collections, expecting to graduate December, 2019. She is a lawyer who has also worked as an administrator at undergraduate and graduate programs, and has taught students from elementary school to graduate level."
+  twitter-handle: "TurnedPageist"
 - name: Mattie Schraeder-Urbanowicz
-  bio: ""
-  twitter-handle: ""
+  bio: "Mattie Schraeder-Urbanowicz a PHP and C# developer, creator of the C# MARC Editor application and library, and former employee of Bound to Stay Bound Books."
+  twitter-handle: "FrozenSolidOne"
 - name: Jessica Whu
   bio: ""
   twitter-handle: ""


### PR DESCRIPTION
These are from a doc in the website committee Drive folder. Some Slack handles were provided too but the site currently doesn't use these in any way.