### PR TITLE
fix scholarships nav and past conference info

### DIFF
--- a/general-info/about-c4l.html
+++ b/general-info/about-c4l.html
@@ -20,3 +20,22 @@ active: About Code4Lib
         </div>
     </div>
 </div>
+
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-xs-12">
+            <h2>Conference Information</h2>
+            <p>
+              For more information on the Code4Lib Conference, please see the <a href="/general-info/about-c4l">conference website</a>.
+              You can see write-ups of previous Code4Lib Conferences:
+            </p>
+            <ul>
+                <li><a href="http://journal.code4lib.org/articles/6848">Code4Lib 2012 Conference Report</a></li>
+                <li><a href="http://journal.code4lib.org/articles/4960">Code4Lib 2011 Conference Report</a>
+                <li><a href="http://journal.code4lib.org/articles/2717">Code4Lib 2010 Conference Report</a></li>
+                <li><a href="http://journal.code4lib.org/articles/998">Code4Lib 2009 Conference Report</a></li>
+                <li><a href="http://journal.code4lib.org/articles/72">Code4Lib 2008 Conference Report</a></li>
+            </ul>
+        </div>
+    </div>
+ </div>

--- a/general-info/angel-fund.html
+++ b/general-info/angel-fund.html
@@ -1,10 +1,4 @@
----
-layout: default
-title: Angel Fund
-categories: scholarships
----
-
-<div class="container" id="angel-fund">
+<div class="container-fluid" id="angel-fund">
 	<div class="row">
 		<div class="col-xs-12">
 			<h2>Diversity Scholarships Angel Fund</h2>

--- a/general-info/scholarships.html
+++ b/general-info/scholarships.html
@@ -8,8 +8,8 @@ subnav:
   url: '#criteria'
 - name: 'How to Apply'
   url: '#how-to-apply'
-- name: Individual Giving
-  url: '/general-info/angel-fund'
+- name: 'Individual Giving'
+  url: '#angel-fund'
 ---
 
 {% assign year = site.data.conf.year %}
@@ -205,21 +205,4 @@ subnav:
    </div>
 </div>
 
-<div class="container-fluid">
-   <div class="row">
-       <div class="col-xs-12">
-           <h2>Conference Information</h2>
-           <p>
-             For more information on the Code4Lib Conference, please see the <a href="/general-info/about-c4l">conference website</a>.
-             You can see write-ups of previous Code4Lib Conferences:
-           </p>
-           <ul>
-               <li><a href="http://journal.code4lib.org/articles/6848">Code4Lib 2012 Conference Report</a></li>
-               <li><a href="http://journal.code4lib.org/articles/4960">Code4Lib 2011 Conference Report</a>
-               <li><a href="http://journal.code4lib.org/articles/2717">Code4Lib 2010 Conference Report</a></li>
-               <li><a href="http://journal.code4lib.org/articles/998">Code4Lib 2009 Conference Report</a></li>
-               <li><a href="http://journal.code4lib.org/articles/72">Code4Lib 2008 Conference Report</a></li>
-           </ul>
-       </div>
-   </div>
-</div>
+{% include_relative angel-fund.html %}


### PR DESCRIPTION
adjusted the way the angel fund is linked in scholarships for consistency in the navigation; moved past conference info from the 'scholarships' page to 'about code4lib'