### PR TITLE
add peri-conference display

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -28,7 +28,7 @@ show-daily-menus: false
 # - peri:   for display during the conference. provides homepage links to conference schedule, talks, livestream, etc.
 # - post:   for after the conference is close
 ###########
-homepage-display: pre
+homepage-display: peri
 
 ##########
 # !!!NOTE!!! All 'end-date' vars should be in the following format: YYYY-MM-DD

--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -28,7 +28,7 @@ show-daily-menus: false
 # - peri:   for display during the conference. provides homepage links to conference schedule, talks, livestream, etc.
 # - post:   for after the conference is close
 ###########
-homepage-display: peri
+homepage-display: pre
 
 ##########
 # !!!NOTE!!! All 'end-date' vars should be in the following format: YYYY-MM-DD

--- a/_includes/homepage/event_card.html
+++ b/_includes/homepage/event_card.html
@@ -1,0 +1,19 @@
+<div class="event-card">
+    <div class="card-toolbar {% if include.time == 'pm' %}night{% endif %}">
+        <a href="{{ include.link }}">
+            {% if include.time == 'am' %}
+            <svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg" class="img-avatar" alt="day">
+                <path style="fill: var(--background-color); stroke: var(--primary-color)" d="M6.76 4.84l-1.8-1.79-1.41 1.41 1.79 1.79 1.42-1.41zM4 10.5H1v2h3v-2zm9-9.95h-2V3.5h2V.55zm7.45 3.91l-1.41-1.41-1.79 1.79 1.41 1.41 1.79-1.79zm-3.21 13.7l1.79 1.8 1.41-1.41-1.8-1.79-1.4 1.4zM20 10.5v2h3v-2h-3zm-8-5c-3.31 0-6 2.69-6 6s2.69 6 6 6 6-2.69 6-6-2.69-6-6-6zm-1 16.95h2V19.5h-2v2.95zm-7.45-3.91l1.41 1.41 1.79-1.8-1.41-1.41-1.79 1.8z"/>
+            </svg>
+            {% else %}
+            <svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg" class="img-avatar" alt="night">
+                <path style="fill: var(--background-color); stroke: var(--primary-color)" d="M17.75,4.09L15.22,6.03L16.13,9.09L13.5,7.28L10.87,9.09L11.78,6.03L9.25,4.09L12.44,4L13.5,1L14.56,4L17.75,4.09M21.25,11L19.61,12.25L20.2,14.23L18.5,13.06L16.8,14.23L17.39,12.25L15.75,11L17.81,10.95L18.5,9L19.19,10.95L21.25,11M18.97,15.95C19.8,15.87 20.69,17.05 20.16,17.8C19.84,18.25 19.5,18.67 19.08,19.07C15.17,23 8.84,23 4.94,19.07C1.03,15.17 1.03,8.83 4.94,4.93C5.34,4.53 5.76,4.17 6.21,3.85C6.96,3.32 8.14,4.21 8.06,5.04C7.79,7.9 8.75,10.87 10.95,13.06C13.14,15.26 16.1,16.22 18.97,15.95M17.33,17.97C14.5,17.81 11.7,16.64 9.53,14.5C7.36,12.31 6.2,9.5 6.04,6.68C3.23,9.82 3.34,14.64 6.35,17.66C9.37,20.67 14.19,20.78 17.33,17.97Z" />
+            </svg>
+            {% endif %}
+        </a>
+    </div>
+    <div class="card-body">
+        <h3><a href="{{ include.link }}">{{ include.title }}</a></h3>
+        <p>{{ include.description }}</p>
+    </div>
+</div>

--- a/_includes/homepage/peri_conference.html
+++ b/_includes/homepage/peri_conference.html
@@ -1,0 +1,25 @@
+<div class="row">
+    <div class="col-xs-12 col-md-3 event-day" data-date="2018-02-13T23:59:59">
+        <h2 class="text-center">Feb 13th</h2>
+        {% include homepage/event_card.html time='am' link='/workshops' title='Preconference Workshops' description='Half and full-day workshops about new tech, diversity, much more!' %}
+        {% include homepage/event_card.html time='pm' link='/general-info/venues/#dinner' title='Newcomer Dinner' description='It is a Code4Lib tradition to welcome those who are new to the conference' %}
+    </div>
+    <div class="col-xs-12 col-md-3 event-day" data-date="2018-02-14T23:59:59">
+        <h2 class="text-center">Feb 14th</h2>
+        {% include homepage/event_card.html time='am' link='/schedule/day-1' title='Conference, Day 1' description='Keynote #1 kicks off the conference then talks until 5' %}
+        {% include homepage/event_card.html time='pm' link='/general-info/venues/#gaming' title='Game Night' description='Come join fellow code4libers in a few board or card games' %}
+    </div>
+    <div class="col-xs-12 col-md-3 event-day" data-date="2018-02-15T23:59:59">
+        <h2 class="text-center">Feb 15th</h2>
+        {% include homepage/event_card.html time='am' link='/schedule/day-2' title='Conference, Day 2' description='Talks until 5' %}
+        {% include homepage/event_card.html time='pm' link='/general-info/venues/#reception' title='Reception' description='Join us for the reception at the Great Hall at the Library of Congress' %}
+    </div>
+    <div class="col-xs-12 col-md-3 event-day" data-date="2018-02-16T23:59:59">
+        <h2 class="text-center">Feb 16th</h2>
+        {% include homepage/event_card.html time='am' link='/schedule/day-3' title='Conference, Day 3' description='Keynote #2 closes the conference then talks until noon' %}
+    </div>
+    <div class="col-xs-12 text-center">
+        <h2>Need help?</h2>
+        <a href="/conduct/#officers" class="btn btn-primary btn-lg">Contact a Duty Officer</a>
+    </div>
+</div>

--- a/assets/_scss/_variables.scss
+++ b/assets/_scss/_variables.scss
@@ -95,6 +95,10 @@ $jumbotron-btn-bg:        $primary-dark;
 $jumbotron-btn-color:     $gray-lighter;
 $jumbotron-btn-hover:     darken($primary-dark, 6.5%);
 
+// Event cards
+$day-event:               $accent-light;
+$night-event:             $primary-dark;
+
 //== Scaffolding
 //
 //## Settings for some of the most global styles.

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -831,3 +831,78 @@ p.speaker-inst {
        -webkit-transform: scaleY(1.0);
      }
 }
+
+/* ==========================================================================
+   Homepage event-cards
+   ========================================================================== */
+
+.event-day {
+  &.active {
+    transform: scale(1.1);
+  }
+  &.past {
+    opacity: .7;
+  }
+}
+
+.event-card {
+  background: #fff;
+  border-radius: 5px;
+  box-shadow: 3px 3px 9px rgba(0,0,0,0.2);
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  margin: .5em 0;
+  overflow: hidden;
+  padding: 0;
+  min-height: 13em;
+  width: 100%;
+
+  .img-avatar {
+    height: auto;
+    width: 4em;
+    border: 2px solid #fff;
+    border-radius: 50%;
+    box-shadow: 0 3px 6px rgba(0,0,0,0.25);
+    box-sizing: border-box;
+    max-width: 100px;
+    background: #fff;
+    --primary-color: #{$sponsor-badge-primary};
+    --background-color: #fff;
+  }
+  %card-content {
+    padding: 1em;
+  }
+  .card-toolbar {
+    @extend %card-content;
+    background: $day-event;
+    color: #fff;
+    height: 3em;
+    .img-avatar {
+      position: relative;
+      left: 50%;
+      top: 0;
+      transform: translateX(-50%);
+      z-index:999;
+    }
+
+    &.night {
+      background: $night-event;
+    }
+  }
+  .card-body {
+    @extend %card-content;
+    padding: 1em 1em .4em;
+    overflow: hidden;
+    text-align: center;
+    h3 {
+      font-size: 1.5em;
+    }
+    p {
+      color: #a1a1a1;
+      margin: 0;
+      line-height: initial;
+    }
+  }
+}
+

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -176,6 +176,20 @@ jQuery(document).ready(function($){
       }
     }, 100));
 
+    // For testing:
+    //var date = new Date('2018-02-15T01:00:00');
+    var date = new Date();
+    $('.event-day').each(function(){
+        var eventDate = new Date($(this).data('date'));
+        console.log([date, eventDate]);
+        if(date > eventDate) {
+            $(this).addClass('past');
+        }
+        if(date.getMonth() == eventDate.getMonth() && date.getDay() == eventDate.getDay()) {
+            $(this).addClass('active');
+        }
+    });
+
 
 
 });

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@ title: code4lib 2018 - Washington, D.C.
 
 <section>
     <div class="container">
+        {% unless site.data.conf.homepage-display == 'peri' %}
         <div class="row">
             <div class="col-xs-12">
                 <h2>The conference for people who code for libraries.</h2>
@@ -16,6 +17,7 @@ title: code4lib 2018 - Washington, D.C.
                 </p>
             </div>
         </div>
+        {% endunless %}
         <div class="row">
             {% include homepage/{{ site.data.conf.homepage-display }}_conference.html %}
         </div>


### PR DESCRIPTION
Closes #57 

For testing:

1. In `_data/conf.yml` change `homepage-display` to `peri`
2. In `assets/js/main.js`, around line 180, comment out `var date = ...` and uncomment the line above it. Change the date here to fake a datetime. This triggers an enlargement of the current day and a fade of previous days.