### PR TITLE
Adds Quiet Room information and policy to accessibility page

### DIFF
--- a/general-info/accessibility.html
+++ b/general-info/accessibility.html
@@ -16,6 +16,47 @@ active: Accessibility
             <h2>Contact</h2>
             <p>Contact <a href="mailto:code4lib.accessibility@gmail.com">code4lib.accessibility@gmail.com</a> with any questions or concerns related ot the conference's accessibility.</p>
 
+            <h2 id="quietroom">Quiet Room</h2>
+            <p>
+               This year, we are providing a quiet room at the conference hotel, 
+               located in the VIP Room, behind the Regency Ballroom (signage will 
+               help direct onsite.) The purpose of this room is to provide a quiet 
+               space so that attendees can take a mental or physical break from 
+               the many goings on. The room is open to all attendees during the 
+               conference hours. 
+            </p>
+            <!-- INSERT MAP IMAGE HERE -->
+            <p>
+               If you use the Quiet Room, we ask you to abide by the following rules:
+            </p>
+            <ul>
+               <li>  The quiet space is not for private discussions or meetings. 
+                     Any talking should be brief and kept to a whisper. 
+               </li>
+               <li>  While in the room, please turn off or silence any electronics, 
+                     especially cellphones. This is not a space to make phone calls,  
+                     catch up on emails, or otherwise do work. This is a space to relax.
+               </li>
+               <li>  If you want to listen to music, watch a video, etc., please 
+                     wear headphones and keep the volume low. If someone asks you 
+                     to further turn down the volume, please do so.
+               </li>
+               <li>  Personal belongings should not be left unattended.
+               </li>
+               <li>  Please leave the space in the same condition (or better) as 
+                     you found it.
+               </li>
+               <li>  Food and drink is permitted but avoid noisy foods or anything 
+                     with strong odors.
+               </li>                     
+               <li>  We will generally keep the lights as low as possible while 
+                     maintaining a safe space.
+               </li>
+               <li>  Above all, respect your fellow conference goers in this space 
+                     so that all of you can find a bit of quiet.
+               </li>
+            </ul>   
+            
             <h2>Accessibility Instructions for Presenters</h2>
             <p>
                 All presenters should please review these accessibility requirements and presentation logistics. Make note


### PR DESCRIPTION
Adds Quiet room information and policy to accessibility page. The heading also has an ID so that a direct link can be made:
http://2018.code4lib.org/general-info/accessibility#quietroom