### PR TITLE
Duty officer update

### DIFF
--- a/_data/duty-officer-schedule.yml
+++ b/_data/duty-officer-schedule.yml
@@ -5,12 +5,12 @@
 
 - title: "Tuesday - Afternoon Preconferences"
   officers:
-    - "matienzo"
-    - "fox" 
+    - "charlton"
+    - "nowviskie"
 
 - title: "Wednesday - Conference Day 1 (Morning)"
   officers:
-    - "charlton"
+    - "matienzo"
     - "fox"
 
 - title: "Wednesday - Conference Day 1 (Afternoon)"
@@ -25,13 +25,13 @@
 
 - title: "Thursday - Conference Day 2 (Morning)"
   officers:
-    - "nowviskie"
-    - "matienzo"
+    - "fox"
+    - "ellis"
 
 - title: "Thursday - Conference Day 2 (Afternoon)"
   officers:
     - "yoose"
-    - "ellis"
+    - "matienzo"
 
 - title: "Thursday - Reception (Evening)"
   all-hands: true

--- a/_data/duty-officers.yml
+++ b/_data/duty-officers.yml
@@ -41,24 +41,24 @@ yoose:
 coyle:
   name: "Karen Coyle"
   onsite: false
-  handle: ""
+  slack_handle: "kcoyle"
 
 hutchinson:
   name: "Josh Hutchinson"
   onsite: false
-  handle: ""
+  slack_handle: "josh_h_uci"
 
 kim:
   name: "Katherine Kim"
   onsite: false
-  handle: ""
+  slack_handle: "katkim"
 
 locascio:
   name: "Jill Locascio"
   onsite: false
-  handle: ""
+  slack_handle: "jkl"
 
 quon:
   name: "Becca Quon"
   onsite: false
-  handle: ""
+  slack_handle: "bquon"

--- a/_data/online-duty-officer-schedule.yml
+++ b/_data/online-duty-officer-schedule.yml
@@ -1,0 +1,47 @@
+- day: Tuesday
+  interval: 9 a.m. - 12 p.m. EST
+  officer: locascio
+
+- day: Tuesday
+  interval: 2 p.m. - 5 p.m. EST
+  officer: quon
+
+- day: Wednesday
+  interval: 9 a.m. - 11 a.m. EST
+  officer: locascio
+
+- day: Wednesday
+  interval: 11 a.m. - 1 p.m. EST
+  officer: coyle
+
+- day: Wednesday
+  interval: 1 p.m. - 3 p.m. EST
+  officer: kim
+
+- day: Wednesday
+  interval: 3 p.m. - 5 p.m. EST
+  officer: hutchinson
+
+- day: Thursday
+  interval: 9 a.m. - 11 a.m. EST
+  officer: locascio
+
+- day: Thursday
+  interval: 11 a.m. - 1 p.m. EST
+  officer: coyle
+
+- day: Thursday
+  interval: 1 p.m. - 3 p.m. EST
+  officer: quon
+
+- day: Thursday
+  interval: 3 p.m. - 5:15 p.m. EST
+  officer: hutchinson
+
+- day: Friday
+  interval: 9 a.m. - 11 a.m. EST
+  officer: kim
+
+- day: Friday
+  interval: 11 a.m. - 12:35 p.m. EST
+  officer: coyle

--- a/conduct/index.html
+++ b/conduct/index.html
@@ -118,9 +118,12 @@ active: 'Conduct & Safety'
 
                     <p>
                       <ul>
+                        <li>Call or text <a href="tel:+17205274957">+1 720-527-4957</a>.</li>
                         <li>Send an email to <a href="mailto:c4l18-duty-officers@googlegroups.com">c4l18-duty-officers@googlegroups.com</a>. Only Duty Officers are subscribed to this mailing list, and no archive is kept.</li>
                         <li>Use the <a href="https://c4l18.libraryexchange.org/">anonymous reporting form</a>.</li>
-                        <li>Use the <code>/dutyofficers</code> command on the <a href="https://code4lib.slack.com/">Code4lib Slack team.</a> Not a member of the Slack team? <a href="https://docs.google.com/forms/d/120Dw1JjLxPJB9VTGl0mUY7Ot6yg6YNY1RZUISJFzdwk/viewform?c=0&w=1">Sign up here</a>.</li>
+                        <li>Use the <code>/dutyofficers</code> command on the <a href="https://code4lib.slack.com/">Code4lib Slack team.</a> Not a member of the Slack team? <a href="https://docs.google.com/forms/d/120Dw1JjLxPJB9VTGl0mUY7Ot6yg6YNY1RZUISJFzdwk/viewform?c=0&w=1">Sign up here</a>. You can also DM the current scheduled online Duty Officer; their Slack handles are listed below.</li>
+                        <li>Approach a Duty Officer in person. Pictures of the on-site Duty Officers are below.</li>
+                        <li>Ask a volunteer at the conference registration desk at the Shoreham Hotel to summon a Duty Officer.</li>
                       </ul>
                     </p>
 

--- a/conduct/index.html
+++ b/conduct/index.html
@@ -9,6 +9,8 @@ subnav:
   url: '#emergency'
 - name: Duty Officers
   url: '#officers'
+- name: Duty Officer Schedule
+  url: '#schedule'
 - name: Accessibility
   url: '/general-info/accessibility'
 - name: Photography Policy
@@ -122,10 +124,10 @@ active: 'Conduct & Safety'
                     </p>
 
                     {% if site.data.duty-officers %}
-                        <div class="row">
                         {% assign onsite_officers = site.data.duty-officers | where:"onsite","true" %}
 
                         <h3> On-Site Duty Officers </h3>
+                        <div class="row">
                         {% for officer in onsite_officers %}
 
                             <div class="col-md-4">
@@ -138,23 +140,29 @@ active: 'Conduct & Safety'
                             </div>
                         {% endfor %}
                         </div>
-                        <div class="row">
+                        <div>
                           <h3> Online Duty Officers</h3>
                           <p> Duty Officers are also present on various online code4lib
-                            platforms, primarily <a href="https://wiki.code4lib.org/How_to_hack_code4lib#Or_get_to_the_.23code4lib_IRC_channel_.28and_other_discussions.29_via_Slack">Slack</a>, IRC, and the <a href="https://twitter.com/hashtag/c4l18">#c4l18</a> conference hashtag feed.
+                            platforms, primarily <a href="https://wiki.code4lib.org/How_to_hack_code4lib#Or_get_to_the_.23code4lib_IRC_channel_.28and_other_discussions.29_via_Slack">Slack</a>. IRC and the <a href="https://twitter.com/hashtag/c4l18">#c4l18</a> conference hashtag feed have some coverage as well, but if you should observe or experience a code of conduct violation on IRC or the hashtag, please contact the duty officers via Slack, email, or the anonymous reporting form.
                           </p>
                           {% assign online_officers = site.data.duty-officers | where:"onsite","false" %}
                           {% for officer in online_officers %}
                           <div class="col-md-4">
                             <h4 class="speaker-name">{{ officer.name }}</h4>
+                            <p>Slack: {{ officer.slack_handle }}</p>
                           </div>
                           {% endfor %}
                         </div>
                     {% endif %}
+                </div>
+           </div>
 
                     {% if site.data.duty-officer-schedule %}
-                        <div class="row">
-                    <h3>Duty Officer Schedule</h3>
+            <div class="row">
+                <div class="col-md-12">
+                    <h2 id="schedule">Duty Officer Schedule</h2>
+
+                       <h3>On-Site</h3>
                     {% for session in site.data.duty-officer-schedule %}
                         <h4>{{ session.title }}</h4>
                         <div class="row">
@@ -175,11 +183,19 @@ active: 'Conduct & Safety'
                             </div>
                         </div>
                     {% endfor %}
-                        </div>
-                    {% endif %}
-
+                       <h3>Online</h3>
+                    {% for period in site.data.online-duty-officer-schedule %}
+                       {% assign officer = site.data.duty-officers[period.officer] %}
+                       <div class="row">
+                          <div class="col-md-2">{{ period.day }}</div>
+                          <div class="col-md-3">{{ period.interval }}</div>
+                          <div class="col-md-4">{{ officer.name }} ({{ officer.slack_handle }})</div>
+                       </div>
+                    {% endfor %}
                 </div>
             </div>
+                    {% endif %}
+
 
             <div class="row">
                 <div class="col-md-12">

--- a/conduct/index.html
+++ b/conduct/index.html
@@ -119,6 +119,7 @@ active: 'Conduct & Safety'
                     <p>
                       <ul>
                         <li>Send an email to <a href="mailto:c4l18-duty-officers@googlegroups.com">c4l18-duty-officers@googlegroups.com</a>. Only Duty Officers are subscribed to this mailing list, and no archive is kept.</li>
+                        <li>Use the <a href="https://c4l18.libraryexchange.org/">anonymous reporting form</a>.</li>
                         <li>Use the <code>/dutyofficers</code> command on the <a href="https://code4lib.slack.com/">Code4lib Slack team.</a> Not a member of the Slack team? <a href="https://docs.google.com/forms/d/120Dw1JjLxPJB9VTGl0mUY7Ot6yg6YNY1RZUISJFzdwk/viewform?c=0&w=1">Sign up here</a>.</li>
                       </ul>
                     </p>


### PR DESCRIPTION
This adds a bunch of updates to the conduct page, including:

- adding more contact points
- adding a link to the anonymous reporting forming
- updates to the duty officer schedule
- add navigation entry for schedule
- add Slack handles for online duty officers
- add schedule for online duty officers
- tweak text regarding online duty officer